### PR TITLE
Fix bug for unsupported locales

### DIFF
--- a/lib/src/localization/app_localizations_provider.dart
+++ b/lib/src/localization/app_localizations_provider.dart
@@ -6,10 +6,10 @@ import 'dart:ui' as ui;
 /// provider used to access the AppLocalizations object for the current locale
 final appLocalizationsProvider = Provider<AppLocalizations>((ref) {
   // set the initial locale
-  ref.state = lookupAppLocalizations(ui.window.locale);
+  ref.state = lookupAppLocalizations(basicLocaleListResolution([ui.window.locale], AppLocalizations.supportedLocales));
   // update afterwards
   final observer = _LocaleObserver((locales) {
-    ref.state = lookupAppLocalizations(ui.window.locale);
+    ref.state = lookupAppLocalizations(basicLocaleListResolution([ui.window.locale], AppLocalizations.supportedLocales));
   });
   final binding = WidgetsBinding.instance;
   binding.addObserver(observer);


### PR DESCRIPTION
Without this fix, developers may be impacted by a somewhat sneaky bug.

Everything will work, until a user whose device is running an unsupported locale tries to use the app, and then the app will crash. This is because within the MaterialApp logic, unsupported locales are gracefully handled by the default locale resolution algorithm [basicLocaleListResolution].

What this fix does is reuses that Flutter provided solution within the provider logic as well.