### PR TITLE
Replaced `window` with new syntax since window is deprecated

### DIFF
--- a/lib/src/localization/app_localizations_provider.dart
+++ b/lib/src/localization/app_localizations_provider.dart
@@ -5,13 +5,11 @@ import 'dart:ui' as ui;
 
 /// provider used to access the AppLocalizations object for the current locale
 final appLocalizationsProvider = Provider<AppLocalizations>((ref) {
-  final Locale locale = WidgetsBinding.instance.platformDispatcher.locale;
-  
   // set the initial locale
-  ref.state = lookupAppLocalizations(basicLocaleListResolution([locale], AppLocalizations.supportedLocales));
+  ref.state = lookupAppLocalizations(basicLocaleListResolution([WidgetsBinding.instance.platformDispatcher.locale], AppLocalizations.supportedLocales));
   // update afterwards
   final observer = _LocaleObserver((locales) {
-    ref.state = lookupAppLocalizations(basicLocaleListResolution([locale], AppLocalizations.supportedLocales));
+    ref.state = lookupAppLocalizations(basicLocaleListResolution([WidgetsBinding.instance.platformDispatcher.locale], AppLocalizations.supportedLocales));
   });
   final binding = WidgetsBinding.instance;
   binding.addObserver(observer);

--- a/lib/src/localization/app_localizations_provider.dart
+++ b/lib/src/localization/app_localizations_provider.dart
@@ -5,11 +5,13 @@ import 'dart:ui' as ui;
 
 /// provider used to access the AppLocalizations object for the current locale
 final appLocalizationsProvider = Provider<AppLocalizations>((ref) {
+  final Locale locale = WidgetsBinding.instance.platformDispatcher.locale;
+  
   // set the initial locale
-  ref.state = lookupAppLocalizations(basicLocaleListResolution([ui.window.locale], AppLocalizations.supportedLocales));
+  ref.state = lookupAppLocalizations(basicLocaleListResolution([locale], AppLocalizations.supportedLocales));
   // update afterwards
   final observer = _LocaleObserver((locales) {
-    ref.state = lookupAppLocalizations(basicLocaleListResolution([ui.window.locale], AppLocalizations.supportedLocales));
+    ref.state = lookupAppLocalizations(basicLocaleListResolution([locale], AppLocalizations.supportedLocales));
   });
   final binding = WidgetsBinding.instance;
   binding.addObserver(observer);


### PR DESCRIPTION
`window` is deprecated since Flutter 3.7.0
I replaced it by the new syntax from https://docs.flutter.dev/release/breaking-changes/window-singleton